### PR TITLE
Lookup, rather than deduce, zone file paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Create `/etc/zone-handler.json` based on [zone-handler.json.example](zone-handle
 
 ```
 python3 -m venv /opt/ssh-zone-handler
-/opt/ssh-zone-handler/bin/pip3 install git+https://github.com/andreaso/ssh-zone-handler.git@v0.1.0
+/opt/ssh-zone-handler/bin/pip3 install git+https://github.com/andreaso/ssh-zone-handler.git@v0.1.1
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssh-zone-handler"
-version = "0.1.0"
+version = "0.1.1"
 description = "SSH commands to provide Secondary DNS self-service."
 readme = "README.md"
 license = "MIT"

--- a/ssh_zone_handler/commands.py
+++ b/ssh_zone_handler/commands.py
@@ -68,8 +68,8 @@ def _usage() -> None:
 
 def _dump(zone: str, zone_paths: str) -> None:
     zone_file: str = zone_paths.format(zone_name=zone)
-    failure: str = f'Failed to dump content of zone "{zone}"'
-    command: Sequence[str] = (
+    failure = f'Failed to dump content of zone "{zone}"'
+    command = (
         "/usr/bin/named-compilezone",
         "-f",
         "raw",
@@ -86,8 +86,8 @@ def _dump(zone: str, zone_paths: str) -> None:
 
 
 def _logs(zone: str, log_user: str) -> None:
-    failure: str = f'Failed to output log lines for zone "{zone}"'
-    command: Sequence[str] = ("/usr/bin/sudo", f"--user={log_user}") + JOURNALCTL
+    failure = f'Failed to output log lines for zone "{zone}"'
+    command = ("/usr/bin/sudo", f"--user={log_user}") + JOURNALCTL
 
     result: CompletedProcess[str] = _runner(command, failure)
 
@@ -98,8 +98,8 @@ def _logs(zone: str, log_user: str) -> None:
 
 
 def _retransfer(zone: str, rndc_user: str) -> None:
-    failure: str = f'Failed to trigger retransfer of zone "{zone}"'
-    command: Sequence[str] = (
+    failure = f'Failed to trigger retransfer of zone "{zone}"'
+    command = (
         "/usr/bin/sudo",
         f"--user={rndc_user}",
         "/usr/sbin/rndc",
@@ -112,8 +112,8 @@ def _retransfer(zone: str, rndc_user: str) -> None:
 
 
 def _status(zone: str, rndc_user: str) -> None:
-    failure: str = f'Failed to display status for zone "{zone}"'
-    command: Sequence[str] = (
+    failure = f'Failed to display status for zone "{zone}"'
+    command = (
         "/usr/bin/sudo",
         f"--user={rndc_user}",
         "/usr/sbin/rndc",

--- a/ssh_zone_handler/types.py
+++ b/ssh_zone_handler/types.py
@@ -27,4 +27,3 @@ class ZoneManagerConf(BaseModel):
 
     sudoers: SudoUsers
     users: dict[str, UserConf]
-    zone_paths = "/var/cache/bind/{zone_name}.zone"

--- a/tests/data/alternative-config.json
+++ b/tests/data/alternative-config.json
@@ -9,6 +9,5 @@
         "example.org"
       ]
     }
-  },
-  "zone_paths": "/var/cache/bind/db.{zone_name}"
+  }
 }

--- a/tests/test_ssh_zone_handler.py
+++ b/tests/test_ssh_zone_handler.py
@@ -26,7 +26,6 @@ def test_cli_read_config():
             "alice": {"zones": ["example.com", "example.net"]},
             "bob": {"zones": ["example.org"]},
         },
-        "zone_paths": "/var/cache/bind/{zone_name}.zone",
     }
 
     alternative_config = _read_config("./tests/data/alternative-config.json")
@@ -38,7 +37,6 @@ def test_cli_read_config():
         "users": {
             "bob": {"zones": ["example.org"]},
         },
-        "zone_paths": "/var/cache/bind/db.{zone_name}",
     }
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
There are zone names where the mapping between zone name and file path
might not be fully obvious. Here I'm mostly thinking about classless
in-addr.arpa zones, containg a slash in their zone name.

Not worried about the plural in the zonestatus `files` attribute, as
I'm fairly certain that that plural is only a thing on Primary name
servers, where one might be using `$INCLUDE` entries. On the Secondary
name server everything gets transfered into one big happy zone file.