### PR TITLE
Implement proper logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Create `/etc/zone-handler.json` based on [zone-handler.json.example](zone-handle
 
 ```
 python3 -m venv /opt/ssh-zone-handler
-/opt/ssh-zone-handler/bin/pip3 install git+https://github.com/andreaso/ssh-zone-handler.git@v0.1.3
+/opt/ssh-zone-handler/bin/pip3 install git+https://github.com/andreaso/ssh-zone-handler.git@v0.1.4
 ```
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssh-zone-handler"
-version = "0.1.3"
+version = "0.1.4"
 description = "SSH commands to provide Secondary DNS self-service."
 readme = "README.md"
 license = "MIT"
@@ -28,6 +28,9 @@ profile = "black"
 
 [tool.pylint.'MASTER']
 extension-pkg-allow-list = "pydantic"
+
+[tool.pytest.ini_options]
+log_format = "%(message)s"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/ssh_zone_handler/cli.py
+++ b/ssh_zone_handler/cli.py
@@ -1,6 +1,8 @@
 """CLI scripts entry points"""
 
 import json
+import logging
+import logging.config
 import os
 import pwd
 import sys
@@ -9,13 +11,16 @@ from typing import Final
 from pydantic import ValidationError
 
 from ssh_zone_handler.commands import InvokeError, SshZoneHandler
+from ssh_zone_handler.static import LOGCONF
 from ssh_zone_handler.types import ZoneHandlerConf
 
 CONFIG_FILE: Final[str] = "/etc/zone-handler.json"
 
+logging.config.dictConfig(LOGCONF)
+
 
 def _error_out(message: str) -> None:
-    print(message, file=sys.stderr)
+    logging.critical(message)
     sys.exit(1)
 
 

--- a/ssh_zone_handler/static.py
+++ b/ssh_zone_handler/static.py
@@ -1,0 +1,36 @@
+"""Static configuration"""
+
+from typing import Any, Final
+
+LOGCONF: Final[dict[str, Any]] = {
+    "version": 1,
+    "disable_existing_loggers": True,
+    "formatters": {
+        "console": {
+            "format": "%(message)s",
+        },
+        "syslog": {
+            "format": "ssh-zone-handler[%(process)d]: %(message)s",
+        },
+    },
+    "handlers": {
+        "console": {
+            "class": "logging.StreamHandler",
+            "level": "WARNING",
+            "formatter": "console",
+        },
+        "syslog": {
+            "class": "logging.handlers.SysLogHandler",
+            "address": "/dev/log",
+            "level": "DEBUG",
+            "formatter": "syslog",
+        },
+    },
+    "loggers": {
+        "": {
+            "handlers": ["console", "syslog"],
+            "level": "DEBUG",
+            "propagate": False,
+        },
+    },
+}

--- a/ssh_zone_handler/types.py
+++ b/ssh_zone_handler/types.py
@@ -25,6 +25,5 @@ class ZoneHandlerConf(BaseModel):
     zone-handler.json structure
     """
 
-    debug = False
     sudoers: SudoUsers
     users: dict[str, UserConf]

--- a/tests/data/alternative-config.json
+++ b/tests/data/alternative-config.json
@@ -1,5 +1,4 @@
 {
-  "debug": true,
   "sudoers": {
     "rndc": "named",
     "logs": "odin"


### PR DESCRIPTION
Taking the syslog route since there is native Python support, and
because journald too listens on `/dev/log`.

(Ab)using loglevels to separate what goes the the user's console
versus what goes to syslog.