### PR TITLE
Bump `actions/setup-python` version

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Use Python 3.10
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
Needed to deal with the deprecation of the `set-output` command.