### PR TITLE
Switch to using Poetry's newish dependency groups

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -329,7 +329,7 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "7c7c7a9ac2c20fabf86f3a84d9599750b3a64708d74ff5d6bc4998f10a0349a9"
+content-hash = "5ed80eabbd0aeb7f52aec593e0cb7928f46963d2ad569b401c8fb3baca616a53"
 
 [metadata.files]
 astroid = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ python = "^3.10"
 pydantic = "^1.10.2"
 pyyaml = "^6.0"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 isort = "^5.10.1"
 black = "^22.10.0"
 mypy = "^0.982"


### PR DESCRIPTION
Apparently the old dev dependency format is now deprecated.