### PR TITLE
Use OIDC auth to publish to PyPi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,40 @@
+---
+
+name: Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  pypi:
+    name: PyPi Publish
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Output expected packge version refs/tags/
+        id: expected
+        run: echo "tagref=refs/tags/v$(poetry version --short)" >> "$GITHUB_OUTPUT"
+
+      - name: Fail on mismatch between tag and package version
+        if: github.ref != steps.expected.outputs.tagref
+        run: |
+          echo "Mismatch between pushed tag and package version."
+          exit 1
+
+      - name: Build package
+        run: poetry build
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssh-zone-handler"
-version = "0.3.1"
+version = "0.3.2"
 description = "SSH commands to provide Secondary DNS self-service."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Trying out the https://docs.pypi.org/trusted-publishers/ beta.